### PR TITLE
Add per-provider reasoning_exclude for OpenAI-compatible providers

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -45,12 +45,14 @@ model = "claude-sonnet-4-5"
 # [providers.openai.default]
 # api_key = "your-openai-api-key"
 # model = "gpt-4-turbo"
+# reasoning_exclude = true         # Optional: add reasoning.exclude=true to requests
 
 # OpenAI-compatible providers (OpenRouter, Groq, etc.)
 # [providers.openai_compatible.openrouter]
 # api_key = "your-openrouter-api-key"
 # model = "anthropic/claude-3.5-sonnet"
 # base_url = "https://openrouter.ai/api/v1"
+# reasoning_exclude = true         # Optional: useful for reasoning models via OpenRouter
 
 # =============================================================================
 # Embedded providers (local models via llama.cpp with Metal acceleration)

--- a/crates/g3-config/src/lib.rs
+++ b/crates/g3-config/src/lib.rs
@@ -64,6 +64,7 @@ pub struct OpenAIConfig {
     pub base_url: Option<String>,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f32>,
+    pub reasoning_exclude: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/g3-config/src/tests.rs
+++ b/crates/g3-config/src/tests.rs
@@ -264,4 +264,36 @@ autonomous_max_retry_attempts = 6
         // Test that planner falls back to default provider
         assert_eq!(config.get_planner_provider(), "databricks.default");
     }
+
+    #[test]
+    fn test_openai_compatible_reasoning_exclude_parsing() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("test_config.toml");
+
+        let config_content = format!(r#"
+[providers]
+default_provider = "openrouter.default"
+
+[providers.openai_compatible.openrouter]
+api_key = "test-key"
+model = "x-ai/grok-code-fast-1"
+base_url = "https://openrouter.ai/api/v1"
+reasoning_exclude = true
+
+[agent]
+fallback_default_max_tokens = 32000
+enable_streaming = true
+timeout_seconds = 60
+auto_compact = true
+max_retry_attempts = 3
+autonomous_max_retry_attempts = 6
+{}"#, test_config_footer());
+
+        fs::write(&config_path, config_content).unwrap();
+
+        let config = Config::load(Some(config_path.to_str().unwrap())).unwrap();
+        let openrouter = config.providers.openai_compatible.get("openrouter").unwrap();
+
+        assert_eq!(openrouter.reasoning_exclude, Some(true));
+    }
 }

--- a/crates/g3-core/src/provider_registration.rs
+++ b/crates/g3-core/src/provider_registration.rs
@@ -110,6 +110,7 @@ fn register_openai_providers(
                 openai_config.base_url.clone(),
                 openai_config.max_tokens,
                 openai_config.temperature,
+                openai_config.reasoning_exclude,
             )?;
             registry.register(openai_provider);
         }
@@ -132,6 +133,7 @@ fn register_openai_compatible_providers(
                 openai_config.base_url.clone(),
                 openai_config.max_tokens,
                 openai_config.temperature,
+                openai_config.reasoning_exclude,
             )?;
             registry.register(openai_provider);
         }

--- a/crates/g3-planner/src/llm.rs
+++ b/crates/g3-planner/src/llm.rs
@@ -67,6 +67,7 @@ pub async fn create_planner_provider(
                 openai_config.base_url.clone(),
                 openai_config.max_tokens,
                 openai_config.temperature,
+                openai_config.reasoning_exclude,
             )?;
             Ok(Box::new(provider))
         }

--- a/crates/g3-providers/src/openai.rs
+++ b/crates/g3-providers/src/openai.rs
@@ -10,9 +10,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error};
 
 use crate::{
+    streaming::{make_final_chunk, make_text_chunk},
     CompletionChunk, CompletionRequest, CompletionResponse, CompletionStream, LLMProvider, Message,
     MessageRole, Tool, ToolCall, Usage,
-    streaming::{make_text_chunk, make_final_chunk},
 };
 
 #[derive(Clone)]
@@ -23,6 +23,7 @@ pub struct OpenAIProvider {
     base_url: String,
     max_tokens: Option<u32>,
     _temperature: Option<f32>,
+    reasoning_exclude: Option<bool>,
     name: String,
 }
 
@@ -33,6 +34,7 @@ impl OpenAIProvider {
         base_url: Option<String>,
         max_tokens: Option<u32>,
         temperature: Option<f32>,
+        reasoning_exclude: Option<bool>,
     ) -> Result<Self> {
         Self::new_with_name(
             "openai".to_string(),
@@ -41,6 +43,7 @@ impl OpenAIProvider {
             base_url,
             max_tokens,
             temperature,
+            reasoning_exclude,
         )
     }
 
@@ -51,6 +54,7 @@ impl OpenAIProvider {
         base_url: Option<String>,
         max_tokens: Option<u32>,
         temperature: Option<f32>,
+        reasoning_exclude: Option<bool>,
     ) -> Result<Self> {
         Ok(Self {
             client: Client::new(),
@@ -59,6 +63,7 @@ impl OpenAIProvider {
             base_url: base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
             max_tokens,
             _temperature: temperature,
+            reasoning_exclude,
             name,
         })
     }
@@ -98,7 +103,30 @@ impl OpenAIProvider {
             });
         }
 
+        if self.reasoning_exclude == Some(true) {
+            Self::set_reasoning_exclude(&mut body);
+        }
+
         body
+    }
+
+    fn set_reasoning_exclude(body: &mut serde_json::Value) {
+        let Some(body_obj) = body.as_object_mut() else {
+            return;
+        };
+
+        match body_obj.get_mut("reasoning") {
+            Some(reasoning) => {
+                if let Some(reasoning_obj) = reasoning.as_object_mut() {
+                    reasoning_obj
+                        .entry("exclude".to_string())
+                        .or_insert_with(|| json!(true));
+                }
+            }
+            None => {
+                body_obj.insert("reasoning".to_string(), json!({ "exclude": true }));
+            }
+        }
     }
 
     async fn parse_streaming_response(
@@ -411,6 +439,74 @@ impl LLMProvider for OpenAIProvider {
 
     fn temperature(&self) -> f32 {
         self._temperature.unwrap_or(0.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_provider(reasoning_exclude: Option<bool>) -> OpenAIProvider {
+        OpenAIProvider::new_with_name(
+            "openai.test".to_string(),
+            "key".to_string(),
+            Some("gpt-4o-mini".to_string()),
+            None,
+            None,
+            None,
+            reasoning_exclude,
+        )
+        .expect("provider should construct")
+    }
+
+    #[test]
+    fn create_request_body_includes_reasoning_exclude_when_enabled() {
+        let provider = make_provider(Some(true));
+        let messages = vec![Message::new(MessageRole::User, "ping".to_string())];
+        let body = provider.create_request_body(&messages, None, false, None, None);
+
+        assert_eq!(body["reasoning"]["exclude"], json!(true));
+    }
+
+    #[test]
+    fn create_request_body_skips_reasoning_exclude_when_disabled() {
+        let provider = make_provider(None);
+        let messages = vec![Message::new(MessageRole::User, "ping".to_string())];
+        let body = provider.create_request_body(&messages, None, false, None, None);
+
+        assert!(body.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn set_reasoning_exclude_merges_without_overwriting_existing_exclude() {
+        let mut body = json!({
+            "model": "gpt-4o-mini",
+            "reasoning": {
+                "effort": "medium",
+                "exclude": false
+            }
+        });
+
+        OpenAIProvider::set_reasoning_exclude(&mut body);
+
+        assert_eq!(body["reasoning"]["effort"], json!("medium"));
+        assert_eq!(body["reasoning"]["exclude"], json!(false));
+    }
+
+    #[test]
+    fn set_reasoning_exclude_adds_exclude_when_reasoning_present_without_it() {
+        let mut body = json!({
+            "model": "gpt-4o-mini",
+            "reasoning": {
+                "effort": "high"
+            }
+        });
+
+        OpenAIProvider::set_reasoning_exclude(&mut body);
+
+        assert_eq!(body["reasoning"]["effort"], json!("high"));
+        assert_eq!(body["reasoning"]["exclude"], json!(true));
     }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,7 @@ model = "gpt-4-turbo"            # Model to use
 max_tokens = 4096
 temperature = 0.1
 # base_url = "https://api.openai.com/v1"  # Optional: Custom endpoint
+# reasoning_exclude = true        # Optional: send reasoning.exclude=true
 ```
 
 ### OpenAI-Compatible Providers
@@ -126,6 +127,7 @@ model = "anthropic/claude-3.5-sonnet"
 base_url = "https://openrouter.ai/api/v1"
 max_tokens = 4096
 temperature = 0.1
+reasoning_exclude = true         # Optional: hide reasoning tokens from response content
 
 [providers.openai_compatible.groq]
 api_key = "gsk_..."
@@ -136,6 +138,9 @@ temperature = 0.1
 ```
 
 Reference these as `openrouter.default` or `groq.default` in `default_provider`.
+
+`reasoning_exclude` is optional and defaults to disabled. Enable it per provider when using
+reasoning-capable models where you want concise `content` output.
 
 ### Embedded (Local) Models
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -185,6 +185,7 @@ model = "gpt-4-turbo"            # Model name
 max_tokens = 4096
 temperature = 0.1
 # base_url = "https://api.openai.com/v1"  # Optional
+# reasoning_exclude = true        # Optional: add reasoning.exclude=true
 ```
 
 ### Available Models
@@ -214,6 +215,7 @@ model = "anthropic/claude-3.5-sonnet"
 base_url = "https://openrouter.ai/api/v1"
 max_tokens = 4096
 temperature = 0.1
+reasoning_exclude = true         # Optional: hide reasoning tokens from content
 
 # Groq
 [providers.openai_compatible.groq]
@@ -231,6 +233,9 @@ base_url = "https://api.together.xyz/v1"
 max_tokens = 4096
 temperature = 0.1
 ```
+
+`reasoning_exclude` is optional and disabled by default. Enable it per provider when you want
+reasoning-capable models to return concise `content` without reasoning text.
 
 ### Supported Services
 


### PR DESCRIPTION
## Summary
- add optional `reasoning_exclude` to `OpenAIConfig`
- pass this flag through provider registration (core + planner)
- add OpenAI provider request-body support to send `reasoning: {"exclude": true}` when enabled
- merge into existing `reasoning` object without overwriting an explicit `exclude` value
- document the new option in config examples and provider/config docs

## Why
Reasoning-capable models on OpenAI-compatible APIs can emit large reasoning text in responses. This option allows enabling concise content output per provider (for example, player on OpenRouter) without changing defaults globally.

## Backward compatibility
- default behavior is unchanged (`reasoning_exclude` is optional and disabled by default)
- no changes to providers that do not enable the flag

## Tests
- added config parsing test for `reasoning_exclude` in `g3-config`
- added OpenAI provider unit tests for:
  - flag enabled: `reasoning.exclude` is included
  - flag disabled: no `reasoning` key is injected
  - merge behavior preserves existing `reasoning` fields
  - explicit existing `reasoning.exclude` is not overwritten
- verified with:
  - `cargo test -p g3-config -p g3-providers -p g3-core -p g3-planner`
