### PR TITLE
Remove unused image dependency from g3-computer-control

### DIFF
--- a/crates/g3-computer-control/Cargo.toml
+++ b/crates/g3-computer-control/Cargo.toml
@@ -30,12 +30,10 @@ core-foundation = "0.10"
 cocoa = "0.25"
 objc = "0.2"
 accessibility = "0.2"
-image = "0.25"
 
 # Linux dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = { version = "2.21", features = ["xlib", "xtest"] }
-image = "0.25"
 
 # Windows dependencies
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
## Summary
- remove the unused `image` dependency from `g3-computer-control` on macOS and Linux

## Why
`image` pulled in `zune-jpeg 0.5.12`, which currently fails to compile on Apple Silicon with newer Rust due to unsafe NEON intrinsic calls. `g3-computer-control` does not use `image` at all: screenshots are taken via platform tools/APIs.

## Result
- the `zune-jpeg@0.5.12` dependency path disappears from the workspace
- `cargo build --release -p g3-cli` succeeds again on Apple Silicon in a fresh upstream clone
