### PR TITLE
fix(g3-core): slide cache breakpoint window forward instead of freezing at 4

### DIFF
--- a/crates/g3-core/src/lib.rs
+++ b/crates/g3-core/src/lib.rs
@@ -487,6 +487,81 @@ impl<W: UiWriter> Agent<W> {
             .count()
     }
 
+    /// Maximum number of cache_control breakpoints Anthropic allows per request.
+    const MAX_CACHE_CONTROLS: usize = 4;
+
+    /// Make room for a new cache_control breakpoint by sliding the window forward.
+    ///
+    /// Anthropic caches only up to the last breakpoint, so a long agent session
+    /// needs its breakpoints to keep advancing toward the growing tail. Once the
+    /// 4-breakpoint cap is reached the breakpoints were append-only, which froze
+    /// the last one early and left the tail re-sent uncached every turn.
+    ///
+    /// When already at the cap, this clears the oldest *movable* breakpoint so a
+    /// fresh one can be placed near the stable tail. The very first breakpoint is
+    /// kept as a stable anchor for the large prefix (system + tools + first user
+    /// turn); the oldest tool-result breakpoint after it is the one recycled.
+    /// Returns true if there is room for a new breakpoint (either there already
+    /// was, or one was evicted).
+    fn ensure_cache_control_slot(&mut self) -> bool {
+        if self.count_cache_controls_in_history() < Self::MAX_CACHE_CONTROLS {
+            return true;
+        }
+
+        // Find the oldest breakpoint after the first (anchor) one and clear it.
+        let oldest_movable = self
+            .context_window
+            .conversation_history
+            .iter()
+            .enumerate()
+            .filter(|(_, msg)| msg.cache_control.is_some())
+            .map(|(idx, _)| idx)
+            .nth(1);
+
+        if let Some(idx) = oldest_movable {
+            self.context_window.conversation_history[idx].cache_control = None;
+            true
+        } else {
+            // Only the anchor breakpoint exists at the cap (shouldn't happen with
+            // MAX_CACHE_CONTROLS > 1); leave it in place rather than dropping it.
+            false
+        }
+    }
+
+    /// Build a tool-result user message, attaching a cache_control breakpoint when
+    /// `cadence_hit` is true and the provider supports caching. When the breakpoint
+    /// cap is already reached, the window slides forward so the new breakpoint lands
+    /// near the tail instead of being dropped.
+    fn build_tool_result_message(
+        &mut self,
+        content: String,
+        cadence_hit: bool,
+    ) -> Result<Message> {
+        let should_cache = cadence_hit && self.ensure_cache_control_slot();
+        if should_cache {
+            if let Some(cache_config) = self.get_provider_cache_control() {
+                let provider = self.providers.get(None)?;
+                return Ok(Message::with_cache_control_validated(
+                    MessageRole::User,
+                    content,
+                    cache_config,
+                    provider,
+                ));
+            }
+        }
+        Ok(Message::new(MessageRole::User, content))
+    }
+
+    /// Test-only: drive a single tool-result placement through the real
+    /// breakpoint logic and append it to the context window. Lets tests exercise
+    /// the sliding-window behavior without standing up the full streaming loop.
+    #[doc(hidden)]
+    pub fn push_tool_result_for_test(&mut self, content: &str, cadence_hit: bool) -> Result<()> {
+        let message = self.build_tool_result_message(content.to_string(), cadence_hit)?;
+        self.context_window.add_message(message);
+        Ok(())
+    }
+
     /// Get the cache control config for the current provider (if Anthropic with cache enabled).
     fn get_provider_cache_control(&self) -> Option<CacheControl> {
         let provider = self.providers.get(None).ok()?;
@@ -1018,11 +1093,13 @@ impl<W: UiWriter> Agent<W> {
                         .await
                         .unwrap_or_else(|e| format!("Error: {}", e));
 
-                    // Add cache_control to the last user message if provider supports it (anthropic)
+                    // Add cache_control to the last user message if provider supports it (anthropic).
+                    // Slide the window forward when the 4-breakpoint cap is reached so the
+                    // breakpoint lands near the tail rather than being dropped.
                     let is_last = idx == message_count - 1;
                     let result_message = if supports_cache
                         && is_last
-                        && self.count_cache_controls_in_history() < 4
+                        && self.ensure_cache_control_slot()
                     {
                         Message::with_cache_control(
                             MessageRole::User,
@@ -2590,26 +2667,12 @@ Skip if nothing new. Be brief."#;
                             let mut result_message = {
                                 let content = format!("Tool result: {}", tool_result);
 
-                                // Apply cache control every 10 tool calls (max 4 annotations)
-                                let should_cache = self.tool_call_count > 0
-                                    && self.tool_call_count % 10 == 0
-                                    && self.count_cache_controls_in_history() < 4;
-
-                                if should_cache {
-                                    let provider = self.providers.get(None)?;
-                                    if let Some(cache_config) = self.get_provider_cache_control() {
-                                        Message::with_cache_control_validated(
-                                            MessageRole::User,
-                                            content,
-                                            cache_config,
-                                            provider,
-                                        )
-                                    } else {
-                                        Message::new(MessageRole::User, content)
-                                    }
-                                } else {
-                                    Message::new(MessageRole::User, content)
-                                }
+                                // Apply cache control every 10 tool calls, sliding the
+                                // breakpoint window forward once the 4-breakpoint cap is
+                                // reached (see build_tool_result_message).
+                                let cadence_hit =
+                                    self.tool_call_count > 0 && self.tool_call_count % 10 == 0;
+                                self.build_tool_result_message(content, cadence_hit)?
                             };
 
                             // Link the tool result to the tool_use ID so providers can

--- a/crates/g3-core/tests/cache_breakpoint_window_test.rs
+++ b/crates/g3-core/tests/cache_breakpoint_window_test.rs
@@ -1,0 +1,146 @@
+//! Regression test for the prompt-cache breakpoint sliding window.
+//!
+//! Anthropic caches the request prefix only up to the last `cache_control`
+//! breakpoint, and allows at most 4 breakpoints per request. The agent places a
+//! breakpoint on every 10th tool result. Previously the placement was gated by
+//! `count_cache_controls_in_history() < 4`, so once 4 breakpoints accumulated
+//! (the first user message plus tool results #10/#20/#30) the guard stayed false
+//! forever and the last breakpoint froze near the start of a long session. The
+//! growing tail past that frozen breakpoint was then re-sent uncached every turn.
+//!
+//! The fix slides the 4-breakpoint window forward: when the cap is reached the
+//! oldest movable breakpoint is recycled so a fresh one can be placed near the
+//! tail. This test drives >40 tool results through the real placement path and
+//! asserts the last breakpoint advances while the total stays within the cap.
+
+use g3_core::ui_writer::NullUiWriter;
+use g3_core::Agent;
+use g3_providers::mock::{MockProvider, MockResponse};
+use g3_providers::ProviderRegistry;
+
+/// Build a config whose default Anthropic provider has caching enabled, so
+/// `get_provider_cache_control()` returns a real cache config.
+fn config_with_anthropic_cache() -> g3_config::Config {
+    let mut config = g3_config::Config::default();
+    config.providers.anthropic.insert(
+        "default".to_string(),
+        g3_config::AnthropicConfig {
+            api_key: "test-key".to_string(),
+            model: "claude-test".to_string(),
+            max_tokens: Some(4096),
+            temperature: None,
+            cache_config: Some("ephemeral".to_string()),
+            enable_1m_context: None,
+            thinking_budget_tokens: None,
+        },
+    );
+    config
+}
+
+async fn create_agent() -> Agent<NullUiWriter> {
+    // Name the mock provider "anthropic" so it resolves to the anthropic config
+    // (config_name defaults to "default") and caching is considered supported.
+    let provider = MockProvider::new()
+        .with_name("anthropic")
+        .with_cache_control_support(true)
+        .with_default_response(MockResponse::text("done"));
+
+    let mut registry = ProviderRegistry::new();
+    registry.register(provider);
+
+    Agent::new_for_test(config_with_anthropic_cache(), NullUiWriter, registry)
+        .await
+        .expect("Failed to create agent")
+}
+
+/// Count cache_control breakpoints in the conversation history.
+fn count_cache_controls(agent: &Agent<NullUiWriter>) -> usize {
+    agent
+        .get_context_window()
+        .conversation_history
+        .iter()
+        .filter(|m| m.cache_control.is_some())
+        .count()
+}
+
+/// Index of the last (newest) cache_control breakpoint in the history.
+fn last_cache_control_index(agent: &Agent<NullUiWriter>) -> Option<usize> {
+    agent
+        .get_context_window()
+        .conversation_history
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.cache_control.is_some())
+        .map(|(idx, _)| idx)
+        .next_back()
+}
+
+#[tokio::test]
+async fn breakpoint_window_slides_forward_past_the_cap() {
+    let mut agent = create_agent().await;
+
+    // Seed the conversation and place the anchor breakpoint on the first user
+    // message (this is the breakpoint that should stay put).
+    agent
+        .execute_task("kick off a long session", None, false)
+        .await
+        .expect("initial task should succeed");
+
+    let breakpoints_after_seed = count_cache_controls(&agent);
+    assert!(
+        breakpoints_after_seed >= 1,
+        "expected an anchor breakpoint on the first user message, got {breakpoints_after_seed}",
+    );
+
+    // Drive 30 tool results. Breakpoints land on #10/#20/#30, which together with
+    // the anchor reaches the 4-breakpoint cap. Record where the last breakpoint
+    // sits at the cap — under the old append-only behavior it freezes here.
+    let mut frozen_last_index = None;
+    for n in 1..=30 {
+        let cadence_hit = n % 10 == 0;
+        agent
+            .push_tool_result_for_test(&format!("tool result {n}"), cadence_hit)
+            .expect("tool result placement should succeed");
+        if n == 30 {
+            frozen_last_index = last_cache_control_index(&agent);
+        }
+    }
+
+    assert_eq!(
+        count_cache_controls(&agent),
+        4,
+        "should be at the 4-breakpoint cap after 30 tool results",
+    );
+    let frozen_last_index = frozen_last_index.expect("a breakpoint should exist at the cap");
+
+    // Keep going well past the cap (41 total). With the sliding window, the last
+    // breakpoint must advance toward the tail instead of staying frozen.
+    for n in 31..=41 {
+        let cadence_hit = n % 10 == 0; // #40
+        agent
+            .push_tool_result_for_test(&format!("tool result {n}"), cadence_hit)
+            .expect("tool result placement should succeed");
+    }
+
+    let total = count_cache_controls(&agent);
+    assert!(
+        total <= 4,
+        "total breakpoints must never exceed Anthropic's cap of 4, got {total}",
+    );
+
+    let advanced_last_index =
+        last_cache_control_index(&agent).expect("a breakpoint should still exist");
+    assert!(
+        advanced_last_index > frozen_last_index,
+        "last breakpoint should advance past the frozen position {frozen_last_index}, \
+         but it is at {advanced_last_index}",
+    );
+
+    // The advanced breakpoint should sit near the growing tail, not back at the
+    // early frozen spot — confirming the tail is now inside the cached prefix.
+    let history_len = agent.get_context_window().conversation_history.len();
+    assert!(
+        history_len - advanced_last_index <= 2,
+        "advanced breakpoint should be near the tail (len {history_len}, idx {advanced_last_index})",
+    );
+}

--- a/crates/g3-providers/src/mock.rs
+++ b/crates/g3-providers/src/mock.rs
@@ -322,6 +322,7 @@ pub struct MockProvider {
     max_tokens: u32,
     temperature: f32,
     native_tool_calling: bool,
+    supports_cache_control: bool,
     /// Queue of responses to return (FIFO)
     responses: Arc<Mutex<Vec<MockResponse>>>,
     /// All requests received (for verification)
@@ -339,6 +340,7 @@ impl MockProvider {
             max_tokens: 4096,
             temperature: 0.7,
             native_tool_calling: false,
+            supports_cache_control: false,
             responses: Arc::new(Mutex::new(Vec::new())),
             requests: Arc::new(Mutex::new(Vec::new())),
             default_response: None,
@@ -372,6 +374,12 @@ impl MockProvider {
     /// Enable native tool calling
     pub fn with_native_tool_calling(mut self, enabled: bool) -> Self {
         self.native_tool_calling = enabled;
+        self
+    }
+
+    /// Enable cache_control support (as the Anthropic provider reports).
+    pub fn with_cache_control_support(mut self, enabled: bool) -> Self {
+        self.supports_cache_control = enabled;
         self
     }
 
@@ -498,6 +506,10 @@ impl LLMProvider for MockProvider {
 
     fn has_native_tool_calling(&self) -> bool {
         self.native_tool_calling
+    }
+
+    fn supports_cache_control(&self) -> bool {
+        self.supports_cache_control
     }
 
     fn max_tokens(&self) -> u32 {


### PR DESCRIPTION
Fixes #77.

### Problem

The `cache_control` support added in #36 places breakpoints append-only, gated by `count_cache_controls_in_history() < 4`: the first user message gets a breakpoint, then one is added on every 10th tool result.

Anthropic caps `cache_control` at 4 breakpoints per request and caches the prefix only up to the *last* breakpoint. Once four breakpoints accumulate (first user message + tool results #10/#20/#30), the `< 4` guard is permanently false and the last breakpoint freezes at #30. In a long agent session, everything after #30 — the growing tail — then falls outside the cached prefix and is re-sent uncached on every turn, so the cache hit rate degrades the longer the session runs.

### Fix

Slide the 4-breakpoint window forward instead of freezing it. When the cap is reached, `ensure_cache_control_slot()` recycles the oldest *movable* breakpoint so a fresh one can be placed near the stable tail. The very first breakpoint is kept as a stable anchor for the large prefix (system + tools + first user turn), and we stay within Anthropic's max of 4. This reuses the existing `count_cache_controls_in_history` / `get_provider_cache_control` helpers.

The tool-result placement logic is extracted into `build_tool_result_message()` and shared by the streaming loop and the discovery-playback path, so both honor the sliding window.

### Test

Adds `crates/g3-core/tests/cache_breakpoint_window_test.rs`, a regression test using the `MockProvider` + `Agent::new_for_test` harness. It drives 41 tool results through the real placement path and asserts the last breakpoint advances past the previously frozen position while the total never exceeds 4. The test fails on the old append-only behavior (last breakpoint stuck at the early index) and passes with the sliding window.

`cargo test -p g3-core` is green; `cargo clippy` and `cargo fmt` clean on the changed files.